### PR TITLE
Change test environment from nose to pytest

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,3 +45,5 @@ html_short_title = '%s-%s' % (project, version)
 napoleon_use_ivar = True
 napoleon_use_rtype = False
 napoleon_use_param = False
+
+linkcheck_ignore = [r"https://requires.io/.*"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,54 @@ forced_separate = test_oemof_network
 not_skip = __init__.py
 skip = migrations
 
+[tool:pytest]
+# If a pytest section is found in one of the possible config files
+# (pytest.ini, tox.ini or setup.cfg), then pytest will not look for any others,
+# so if you add a pytest config section elsewhere,
+# you will need to delete this section from setup.cfg.
+norecursedirs =
+    .git
+    .tox
+    .env
+    dist
+    build
+    migrations
+
+python_files =
+    test_*.py
+    *_test.py
+    *_tests.py
+    tests.py
+addopts =
+    -ra
+    --strict
+    --ignore=docs/conf.py
+    --ignore=setup.py
+    --ignore=ci
+    --ignore=.eggs
+    --doctest-modules
+    --doctest-glob=\*.rst
+    --tb=short
+    --pyargs
+# The order of these options matters. testpaths comes after addopts so that
+# oemof.solph in testpaths is interpreted as
+# --pyargs oemof.solph.
+# Any tests in the src/ directory (that is, tests installed with the package)
+# can be run by any user with pytest --pyargs oemof.solph.
+# Packages that are sensitive to the host machine, most famously NumPy,
+# include tests with the installed package so that any user can check
+# at any time that everything is working properly.
+# If you do choose to make installable tests, this will run the installed
+# tests as they are actually installed (same principle as when we ensure that
+# we always test the installed version of the package).
+# If you have no need for this (and your src/ directory is very large),
+# you can save a few milliseconds on testing by telling pytest not to search
+# the src/ directory by removing
+# --pyargs and oemof.solph from the options here.
+testpaths =
+    oemof.network
+    tests/
+
 [matrix]
 # This is the configuration for the `./bootstrap.py` script.
 # It generates `.travis.yml`, `tox.ini` and `.appveyor.yml`.

--- a/tests/basic_tests.py
+++ b/tests/basic_tests.py
@@ -30,7 +30,7 @@ from oemof.network.network import temporarily_modifies_registry
 class TestsEnergySystem:
 
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         cls.timeindex = pd.date_range('1/1/2012', periods=5, freq='H')
 
     def setup(self):

--- a/tests/basic_tests.py
+++ b/tests/basic_tests.py
@@ -22,7 +22,6 @@ from oemof.network.groupings import FlowsWithNodes as FWNs
 from oemof.network.groupings import Grouping
 from oemof.network.groupings import Nodes
 from oemof.network.network import Bus
-from oemof.network.network import Edge
 from oemof.network.network import Entity
 from oemof.network.network import Node
 from oemof.network.network import Transformer

--- a/tests/basic_tests.py
+++ b/tests/basic_tests.py
@@ -9,6 +9,7 @@ available from its original location oemof/tests/basic_tests.py
 SPDX-License-Identifier: MIT
 """
 from collections.abc import Iterable
+from itertools import chain
 from pprint import pformat
 
 import pandas as pd
@@ -21,6 +22,7 @@ from oemof.network.groupings import FlowsWithNodes as FWNs
 from oemof.network.groupings import Grouping
 from oemof.network.groupings import Nodes
 from oemof.network.network import Bus
+from oemof.network.network import Edge
 from oemof.network.network import Entity
 from oemof.network.network import Node
 from oemof.network.network import Transformer
@@ -201,21 +203,24 @@ class TestsEnergySystem:
         key = object()
         ensys = es.EnergySystem(groupings=[Flows(key)])
         Node.registry = ensys
-        flows = (object(), object())
         bus = Bus(label="A Bus")
-        Node(label="A Node", inputs={bus: flows[0]}, outputs={bus: flows[1]})
-        eq_(ensys.groups[key], set(flows))
+        Node(label="A Node", inputs={bus: None}, outputs={bus: None})
+        eq_(
+            ensys.groups[key],
+            set(chain(bus.inputs.values(), bus.outputs.values())),
+        )
 
     @temporarily_modifies_registry
     def test_flows_with_nodes(self):
         key = object()
         ensys = es.EnergySystem(groupings=[FWNs(key)])
         Node.registry = ensys
-        flows = (object(), object())
         bus = Bus(label="A Bus")
-        node = Node(label="A Node",
-                    inputs={bus: flows[0]}, outputs={bus: flows[1]})
-        eq_(ensys.groups[key], {(bus, node, flows[0]), (node, bus, flows[1])})
+        node = Node(label="A Node", inputs={bus: None}, outputs={bus: None})
+        eq_(
+            ensys.groups[key],
+            {(bus, node, bus.outputs[node]), (node, bus, node.outputs[bus])},
+        )
 
     def test_that_node_additions_are_signalled(self):
         """

--- a/tests/test_network_classes.py
+++ b/tests/test_network_classes.py
@@ -335,6 +335,7 @@ class TestsEnergySystemNodesIntegration:
     def test_registry_modification_decorator(self):
         Node("registered")
         ok_("registered" in self.es.groups)
+
         @temporarily_modifies_registry
         def create_a_node():
             Node("not registered")

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ envlist =
 [testenv]
 basepython =
     docs: {env:TOXPYTHON:python3.7}
-    {bootstrap,clean,check,report,coveralls}: {env:TOXPYTHON:python3}
+    {bootstrap,clean,check,report,codecov,coveralls}: {env:TOXPYTHON:python3}
 setenv =
     PYTHONPATH={toxinidir}/tests
     PYTHONUNBUFFERED=yes
@@ -22,8 +22,10 @@ passenv =
     *
 deps =
     nose
+    pytest
+    pytest-travis-fold
 commands =
-    {posargs:nosetests -v tests}
+    {posargs:pytest -vv --ignore=src}
 
 [testenv:bootstrap]
 deps =
@@ -84,10 +86,10 @@ setenv =
     {[testenv]setenv}
 usedevelop = true
 commands =
-    {posargs:nosetests --with-coverage --cover-package=oemof.network}
+    {posargs:pytest --cov --cov-report=term-missing -vv}
 deps =
     {[testenv]deps}
-    coverage
+    pytest-cov
 
 [testenv:py36-nocov]
 basepython = {env:TOXPYTHON:python3.6}
@@ -98,10 +100,10 @@ setenv =
     {[testenv]setenv}
 usedevelop = true
 commands =
-    {posargs:nosetests --with-coverage --cover-package=oemof.network}
+    {posargs:pytest --cov --cov-report=term-missing -vv}
 deps =
     {[testenv]deps}
-    coverage
+    pytest-cov
 
 [testenv:py37-nocov]
 basepython = {env:TOXPYTHON:python3.7}
@@ -112,10 +114,10 @@ setenv =
     {[testenv]setenv}
 usedevelop = true
 commands =
-    {posargs:nosetests --with-coverage --cover-package=oemof.network}
+    {posargs:pytest --cov --cov-report=term-missing -vv}
 deps =
     {[testenv]deps}
-    coverage
+    pytest-cov
 
 [testenv:py38-nocov]
 basepython = {env:TOXPYTHON:python3.8}

--- a/tox.ini
+++ b/tox.ini
@@ -40,12 +40,13 @@ deps =
     docutils
     check-manifest
     flake8
-    readme-renderer
+    twine
     pygments
     isort
 skip_install = true
 commands =
-    python setup.py check --strict --metadata --restructuredtext
+    python setup.py sdist
+    twine check dist/oemof*
     check-manifest {toxinidir}
     flake8 src tests setup.py
     isort --verbose --check-only --diff --recursive src tests setup.py

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ envlist =
 
 [testenv]
 basepython =
-    docs: {env:TOXPYTHON:python3.7}
+    docs: {env:TOXPYTHON:python3}
     {bootstrap,clean,check,report,codecov,coveralls}: {env:TOXPYTHON:python3}
 setenv =
     PYTHONPATH={toxinidir}/tests


### PR DESCRIPTION
Some oemof packages use pytest some nosetest. It will be easier to develop different packages if all packages would use the same tools. As pytest is better maintained I would like to move from nosetests to pytest.

Two test are failing. @gnn Could you help!

The test coverage should increase because pytest integrates the doctests.

[![Coverage Status](https://coveralls.io/repos/github/oemof/oemof.network/badge.svg?branch=dev)](https://coveralls.io/github/oemof/oemof.network?branch=dev) --> [![Coverage Status](https://coveralls.io/repos/github/oemof/oemof.network/badge.svg?branch=features/change-test-environment-from-nose-to-pytest)](https://coveralls.io/github/oemof/oemof.network?branch=features/change-test-environment-from-nose-to-pytest)