### PR TITLE
Update abc imports to Python3.3 syntax

### DIFF
--- a/src/oemof/network/network.py
+++ b/src/oemof/network/network.py
@@ -12,8 +12,8 @@ available from its original location oemof/oemof/network.py
 SPDX-License-Identifier: MIT
 """
 
-from collections import Mapping
-from collections import MutableMapping as MM
+from collections.abc import Mapping
+from collections.abc import MutableMapping as MM
 from collections import UserDict as UD
 from collections import namedtuple as NT
 from contextlib import contextmanager

--- a/src/oemof/network/network.py
+++ b/src/oemof/network/network.py
@@ -12,10 +12,10 @@ available from its original location oemof/oemof/network.py
 SPDX-License-Identifier: MIT
 """
 
-from collections.abc import Mapping
-from collections.abc import MutableMapping as MM
 from collections import UserDict as UD
 from collections import namedtuple as NT
+from collections.abc import Mapping
+from collections.abc import MutableMapping as MM
 from contextlib import contextmanager
 from functools import total_ordering
 


### PR DESCRIPTION
The previous imports will stop working in the upcoming Python 3.9 release.