### PR TITLE
Deprecate node registration

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -20,4 +20,4 @@ recursive-include tests *.py
 
 include tox.ini .travis.yml .appveyor.yml .readthedocs.yml
 
-global-exclude *.py[cod] __pycache__/* *.so *.dylib
+global-exclude *.py[cod] __pycache__/* *.so *.dylib *.swp

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,6 @@ line_length = 120
 known_first_party = oemof.network
 default_section = THIRDPARTY
 forced_separate = test_oemof_network
-not_skip = __init__.py
 skip = migrations
 
 [tool:pytest]

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ universal = 1
 max-line-length = 79
 exclude = */migrations/*[nosetests]
 verbosity = 2
-ignore = E203, W503
+ignore = E203, W503, D203
 
 [pydocstyle]
 ignore = D200, D203, D213, D406, D407

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,12 @@ exclude = */migrations/*[nosetests]
 verbosity = 2
 ignore = E203, W503
 
+[pydocstyle]
+ignore = D200, D203, D213, D406, D407
+
+[pep257]
+ignore = D200, D203, D213, D406, D407
+
 [tool:isort]
 force_single_line = True
 line_length = 79

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,10 @@ norecursedirs =
     build
     migrations
 
+python_classes =
+  Test*
+  *Tests
+
 python_files =
     test_*.py
     *_test.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ python_files =
     *_test.py
     *_tests.py
     tests.py
+
 addopts =
     -ra
     --strict

--- a/src/oemof/network/energy_system.py
+++ b/src/oemof/network/energy_system.py
@@ -91,6 +91,15 @@ class EnergySystem:
     >>> es.add(bus)
     >>> bus is es.groups['electricity']
     True
+    >>> es.dump()  # doctest: +ELLIPSIS
+    'Attributes dumped to:...
+    >>> es = EnergySystem()
+    >>> es.restore()  # doctest: +ELLIPSIS
+    'Attributes restored from:...
+    >>> bus is es.groups['electricity']
+    False
+    >>> es.groups['electricity']
+    "<oemof.network.network.Bus: 'electricity'>"
 
     For simple user defined groupings, you can just supply a function that
     computes a key from an :class:`entity <oemof.core.network.Entity>` and the

--- a/src/oemof/network/network.py
+++ b/src/oemof/network/network.py
@@ -82,8 +82,21 @@ class Outputs(UD):
         return super().__setitem__(key, value)
 
 
+class Metaclass(type):
+    """ The metaclass for objects in an oemof energy system."
+    """
+
+    @property
+    def registry(cls):
+        return cls._registry
+
+    @registry.setter
+    def registry(cls, registry):
+        cls._registry = registry
+
+
 @total_ordering
-class Node:
+class Node(metaclass=Metaclass):
     """ Represents a Node in an energy system graph.
 
     Abstract superclass of the two general types of nodes of an energy system
@@ -120,7 +133,7 @@ class Node:
         information.
     """
 
-    registry = None
+    _registry = None
     __slots__ = ["_label", "_in_edges", "_inputs", "_outputs"]
 
     def __init__(self, *args, **kwargs):

--- a/src/oemof/network/network.py
+++ b/src/oemof/network/network.py
@@ -376,8 +376,7 @@ class Edge(Node):
         self.label = Edge.Label(self.label.input, o)
         if old_output is None and o is not None and self.input is not None:
             del self._delay_registration_
-            if __class__.registry is not None:
-                __class__.registry.add(self)
+            self.register()
             o.inputs[self.input] = self
 
 

--- a/src/oemof/network/network.py
+++ b/src/oemof/network/network.py
@@ -84,8 +84,7 @@ class Outputs(UD):
 
 
 class Metaclass(type):
-    """ The metaclass for objects in an oemof energy system."
-    """
+    """ The metaclass for objects in an oemof energy system."""
 
     @property
     def registry(cls):

--- a/src/oemof/network/network.py
+++ b/src/oemof/network/network.py
@@ -84,7 +84,7 @@ class Outputs(UD):
 
 
 class Metaclass(type):
-    """ The metaclass for objects in an oemof energy system."""
+    """The metaclass for objects in an oemof energy system."""
 
     @property
     def registry(cls):

--- a/src/oemof/network/network.py
+++ b/src/oemof/network/network.py
@@ -12,14 +12,13 @@ available from its original location oemof/oemof/network.py
 SPDX-License-Identifier: MIT
 """
 
+import warnings
 from collections import Mapping
 from collections import MutableMapping as MM
 from collections import UserDict as UD
 from collections import namedtuple as NT
 from contextlib import contextmanager
 from functools import total_ordering
-import warnings
-
 
 # TODO:
 #

--- a/src/oemof/network/network.py
+++ b/src/oemof/network/network.py
@@ -18,6 +18,8 @@ from collections import UserDict as UD
 from collections import namedtuple as NT
 from contextlib import contextmanager
 from functools import total_ordering
+from warnings import warn
+
 
 # TODO:
 #
@@ -88,10 +90,12 @@ class Metaclass(type):
 
     @property
     def registry(cls):
+        warn(cls.registry_warning)
         return cls._registry
 
     @registry.setter
     def registry(cls, registry):
+        warn(cls.registry_warning)
         cls._registry = registry
 
 
@@ -132,6 +136,14 @@ class Node(metaclass=Metaclass):
         <https://docs.python.org/3/reference/datamodel.html#slots>`_ for more
         information.
     """
+
+    registry_warning = FutureWarning(
+        "\nAutomatic registration of `Node`s is deprecated in favour of\n"
+        "explicitly adding `Node`s to an `EnergySystem` via "
+        "`EnergySystem.add`.\n"
+        "This feature, i.e. the `Node.registry` attribute and functionality\n"
+        "pertaining to it, will be removed in future versions.\n"
+    )
 
     _registry = None
     __slots__ = ["_label", "_in_edges", "_inputs", "_outputs"]

--- a/src/oemof/network/network.py
+++ b/src/oemof/network/network.py
@@ -18,7 +18,7 @@ from collections import UserDict as UD
 from collections import namedtuple as NT
 from contextlib import contextmanager
 from functools import total_ordering
-from warnings import warn
+import warnings
 
 
 # TODO:
@@ -90,12 +90,12 @@ class Metaclass(type):
 
     @property
     def registry(cls):
-        warn(cls.registry_warning)
+        warnings.warn(cls.registry_warning)
         return cls._registry
 
     @registry.setter
     def registry(cls, registry):
-        warn(cls.registry_warning)
+        warnings.warn(cls.registry_warning)
         cls._registry = registry
 
 

--- a/src/oemof/network/network.py
+++ b/src/oemof/network/network.py
@@ -215,7 +215,11 @@ class Node(metaclass=Metaclass):
         """
 
     def register(self):
-        if __class__.registry is not None and not getattr(
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            registry = __class__.registry
+
+        if registry is not None and not getattr(
             self, "_delay_registration_", False
         ):
             __class__.registry.add(self)

--- a/tests/basic_tests.py
+++ b/tests/basic_tests.py
@@ -12,7 +12,6 @@ from collections.abc import Iterable
 from itertools import chain
 from pprint import pformat
 
-import pandas as pd
 from nose.tools import eq_
 from nose.tools import ok_
 
@@ -24,29 +23,14 @@ from oemof.network.groupings import Nodes
 from oemof.network.network import Bus
 from oemof.network.network import Entity
 from oemof.network.network import Node
-from oemof.network.network import Transformer
 from oemof.network.network import temporarily_modifies_registry
 
 
 class TestsEnergySystem:
 
-    @classmethod
-    def setup_class(cls):
-        cls.timeindex = pd.date_range('1/1/2012', periods=5, freq='H')
-
     def setup(self):
         self.es = es.EnergySystem()
         Node.registry = self.es
-
-    def test_entity_registration(self):
-        bus = Bus(label='bus-uid', type='bus-type')
-        eq_(self.es.nodes[0], bus)
-        bus2 = Bus(label='bus-uid2', type='bus-type')
-        eq_(self.es.nodes[1], bus2)
-        t1 = Transformer(label='pp_gas', inputs=[bus], outputs=[bus2])
-        ok_(t1 in self.es.nodes)
-        self.es.timeindex = self.timeindex
-        ok_(len(self.es.timeindex) == 5)
 
     def test_entity_grouping_on_construction(self):
         bus = Bus(label="test bus")

--- a/tests/basic_tests.py
+++ b/tests/basic_tests.py
@@ -207,7 +207,7 @@ class TestsEnergySystem:
         ensys = es.EnergySystem(groupings=[FWNs(key)])
         bus = Bus(label="A Bus")
         node = Node(label="A Node", inputs={bus: None}, outputs={bus: None})
-	ensys.add(bus, node)
+        ensys.add(bus, node)
         assert ensys.groups[key], {
             (bus, node, bus.outputs[node]),
             (node, bus, node.outputs[bus]),

--- a/tests/basic_tests.py
+++ b/tests/basic_tests.py
@@ -186,6 +186,7 @@ class TestsEnergySystem:
         collect_everything = Nodes(constant_key=everything)
         ensys = es.EnergySystem(groupings=[collect_everything])
         node = Node(label="A Node")
+        ensys.add(node)
         assert "everything" not in ensys.groups
         assert everything in ensys.groups
         assert ensys.groups[everything] == {node}

--- a/tests/basic_tests.py
+++ b/tests/basic_tests.py
@@ -12,9 +12,6 @@ from collections.abc import Iterable
 from itertools import chain
 from pprint import pformat
 
-from nose.tools import eq_
-from nose.tools import ok_
-
 from oemof.network import energy_system as es
 from oemof.network.groupings import Flows
 from oemof.network.groupings import FlowsWithNodes as FWNs
@@ -81,19 +78,15 @@ class TestsEnergySystem:
         ]
         ensy.add(*nodes)
         for group in ["Foo", "Bar", "A", "B"]:
-            eq_(
+            assert len(ensy.groups[group]) == 5, (
+                "\n  Failed testing length of group '{}'."
+                + "\n  Expected: 5"
+                + "\n  Got     : {}"
+                + "\n  Group   : {}"
+            ).format(
+                group,
                 len(ensy.groups[group]),
-                5,
-                (
-                    "\n  Failed testing length of group '{}'."
-                    + "\n  Expected: 5"
-                    + "\n  Got     : {}"
-                    + "\n  Group   : {}"
-                ).format(
-                    group,
-                    len(ensy.groups[group]),
-                    sorted([e.label for e in ensy.groups[group]]),
-                ),
+                sorted([e.label for e in ensy.groups[group]]),
             )
 
     def test_grouping_filter_parameter(self):

--- a/tests/basic_tests.py
+++ b/tests/basic_tests.py
@@ -26,7 +26,6 @@ from oemof.network.network import Node
 
 
 class TestsEnergySystem:
-
     def setup(self):
         self.es = es.EnergySystem()
 
@@ -52,10 +51,10 @@ class TestsEnergySystem:
 
         ensys = es.EnergySystem(groupings=[by_uid])
 
-        ungrouped = [Entity(uid="Not in 'Group': {}".format(i))
-                     for i in range(10)]
-        grouped = [Entity(uid="In 'Group': {}".format(i))
-                   for i in range(10)]
+        ungrouped = [
+            Entity(uid="Not in 'Group': {}".format(i)) for i in range(10)
+        ]
+        grouped = [Entity(uid="In 'Group': {}".format(i)) for i in range(10)]
         ok_(None not in ensys.groups)
         for g in ensys.groups.values():
             for e in ungrouped:
@@ -82,19 +81,29 @@ class TestsEnergySystem:
         ]
         ensy.add(*nodes)
         for group in ["Foo", "Bar", "A", "B"]:
-            eq_(len(ensy.groups[group]), 5,
-                ("\n  Failed testing length of group '{}'." +
-                 "\n  Expected: 5" +
-                 "\n  Got     : {}" +
-                 "\n  Group   : {}").format(
-                    group, len(ensy.groups[group]),
-                    sorted([e.label for e in ensy.groups[group]])))
+            eq_(
+                len(ensy.groups[group]),
+                5,
+                (
+                    "\n  Failed testing length of group '{}'."
+                    + "\n  Expected: 5"
+                    + "\n  Got     : {}"
+                    + "\n  Group   : {}"
+                ).format(
+                    group,
+                    len(ensy.groups[group]),
+                    sorted([e.label for e in ensy.groups[group]]),
+                ),
+            )
 
     def test_grouping_filter_parameter(self):
-        g1 = Grouping(key=lambda e: "The Special One",
-                      filter=lambda e: "special" in str(e))
-        g2 = Nodes(key=lambda e: "A Subset",
-                   filter=lambda e: "subset" in str(e))
+        g1 = Grouping(
+            key=lambda e: "The Special One",
+            filter=lambda e: "special" in str(e),
+        )
+        g2 = Nodes(
+            key=lambda e: "A Subset", filter=lambda e: "subset" in str(e)
+        )
         ensys = es.EnergySystem(groupings=[g1, g2])
         special = Node(label="special")
         subset = set(Node(label="subset: {}".format(i)) for i in range(10))
@@ -112,8 +121,11 @@ class TestsEnergySystem:
         retained.
         This test makes sure that the bug doesn't resurface again.
         """
-        g = Nodes(key="group", value=lambda _: {1, 2, 3, 4},
-                  filter=lambda x: x % 2 == 0)
+        g = Nodes(
+            key="group",
+            value=lambda _: {1, 2, 3, 4},
+            filter=lambda x: x % 2 == 0,
+        )
         ensys = es.EnergySystem(groupings=[g])
         special = Node(label="object")
         ensys.add(special)
@@ -121,8 +133,9 @@ class TestsEnergySystem:
 
     def test_non_callable_group_keys(self):
         collect_everything = Nodes(key="everything")
-        g1 = Grouping(key="The Special One",
-                      filter=lambda e: "special" in e.label)
+        g1 = Grouping(
+            key="The Special One", filter=lambda e: "special" in e.label
+        )
         g2 = Nodes(key="A Subset", filter=lambda e: "subset" in e.label)
         ensys = es.EnergySystem(groupings=[g1, g2, collect_everything])
         special = Node(label="special")
@@ -151,19 +164,22 @@ class TestsEnergySystem:
         self.es.add(*buses[1:])
         ok_(
             group in self.es.groups,
-            "\nExpected to find\n\n  `{!r}`\n\nin `es.groups`.\nGot:\n\n  `{}`"
-            .format(
+            (
+                "\nExpected to find"
+                "\n\n  `{!r}`\n\n"
+                "in `es.groups`.\n"
+                "Got:\n\n  `{}`"
+            ).format(
                 group,
                 "\n   ".join(pformat(set(self.es.groups.keys())).split("\n")),
             ),
         )
         ok_(
             buses[0] in self.es.groups[group],
-            "\nExpected\n\n  `{}`\n\nin `es.groups['{}']`:\n\n  `{}`"
-            .format(
+            "\nExpected\n\n  `{}`\n\nin `es.groups['{}']`:\n\n  `{}`".format(
                 "\n   ".join(pformat(buses[0]).split("\n")),
                 group,
-                "\n   ".join(pformat(self.es.groups[group]).split("\n"))
+                "\n   ".join(pformat(self.es.groups[group]).split("\n")),
             ),
         )
 
@@ -174,7 +190,10 @@ class TestsEnergySystem:
         without having to worry about `Grouping`s trying to call them. This
         test makes sure that the parameter is handled correctly.
         """
-        def everything(): return "everything"
+
+        def everything():
+            return "everything"
+
         collect_everything = Nodes(constant_key=everything)
         ensys = es.EnergySystem(groupings=[collect_everything])
         node = Node(label="A Node")
@@ -213,7 +232,7 @@ class TestsEnergySystem:
 
         def subscriber(sender, **kwargs):
             ok_(sender is node)
-            ok_(kwargs['EnergySystem'] is self.es)
+            ok_(kwargs["EnergySystem"] is self.es)
             subscriber.called = True
 
         subscriber.called = False

--- a/tests/node_registration_tests.py
+++ b/tests/node_registration_tests.py
@@ -19,6 +19,7 @@ import warnings
 import pandas as pd
 import pytest
 
+from oemof.network.energy_system import EnergySystem
 from oemof.network.network import Node
 
 
@@ -51,3 +52,11 @@ class NodeRegistrationTests:
                     "\n---\n".join([str(w.message) for w in recorded])
                 )
             )
+
+    def test_that_node_creation_emits_a_warning_if_registry_is_not_none(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            Node.registry = EnergySystem()
+
+        with pytest.warns(FutureWarning):
+            n = Node()

--- a/tests/node_registration_tests.py
+++ b/tests/node_registration_tests.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -
+
+""" Tests pertaining to :obj:`node <oemof.network.network.Node>` registration via :attr:`Node.registry <oemof.network.network.Node.registry>`.
+
+This test suite (eventually) collects all tests revolving around automatically
+registering :obj:`nodes <oemof.network.network.Node>` in an
+:obj:`energy system <oemof.network.EnergySystem>`. Since this feature is
+deprecated, having all tests pertaining to it in one file makes it easier to
+remove them all at once, when the feature is romved.
+
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted
+by the contributors recorded in the version control history of the file,
+available from its original location oemof/tests/basic_tests.py
+
+SPDX-License-Identifier: MIT
+"""
+import warnings
+
+import pandas as pd
+import pytest
+
+from oemof.network.network import Node
+
+
+class NodeRegistrationTests:
+
+    # TODO: Move all other registration tests into this test suite.
+    def test_that_setting_a_node_registry_emits_a_warning(self):
+        with pytest.warns(FutureWarning):
+            Node.registry = 1
+
+    def test_that_accessing_the_node_registry_emits_a_warning(self):
+        with pytest.warns(FutureWarning):
+            Node.registry

--- a/tests/node_registration_tests.py
+++ b/tests/node_registration_tests.py
@@ -16,20 +16,41 @@ SPDX-License-Identifier: MIT
 """.format("<oemof.network.network.Node>")
 import warnings
 
+import pandas as pd
 import pytest
+from nose.tools import eq_
+from nose.tools import ok_
 
 from oemof.network.energy_system import EnergySystem
+from oemof.network.network import Bus
 from oemof.network.network import Node
+from oemof.network.network import Transformer
 
 
 class NodeRegistrationTests:
 
     # TODO: Move all other registration tests into this test suite.
 
+    @classmethod
+    def setup_class(cls):
+        cls.timeindex = pd.date_range('1/1/2012', periods=5, freq='H')
+
     def setup(self):
+        self.es = EnergySystem()
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             Node.registry = None
+
+    def test_entity_registration(self):
+        Node.registry = self.es
+        bus = Bus(label='bus-uid', type='bus-type')
+        eq_(self.es.nodes[0], bus)
+        bus2 = Bus(label='bus-uid2', type='bus-type')
+        eq_(self.es.nodes[1], bus2)
+        t1 = Transformer(label='pp_gas', inputs=[bus], outputs=[bus2])
+        ok_(t1 in self.es.nodes)
+        self.es.timeindex = self.timeindex
+        ok_(len(self.es.timeindex) == 5)
 
     def test_that_setting_a_node_registry_emits_a_warning(self):
         with pytest.warns(FutureWarning):

--- a/tests/node_registration_tests.py
+++ b/tests/node_registration_tests.py
@@ -42,15 +42,17 @@ class NodeRegistrationTests:
             Node.registry = None
 
     def test_entity_registration(self):
-        Node.registry = self.es
-        bus = Bus(label="bus-uid", type="bus-type")
-        assert self.es.nodes[0] == bus
-        bus2 = Bus(label="bus-uid2", type="bus-type")
-        assert self.es.nodes[1] == bus2
-        t1 = Transformer(label="pp_gas", inputs=[bus], outputs=[bus2])
-        assert t1 in self.es.nodes
-        self.es.timeindex = self.timeindex
-        assert len(self.es.timeindex) == 5
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            Node.registry = self.es
+            bus = Bus(label="bus-uid", type="bus-type")
+            assert self.es.nodes[0] == bus
+            bus2 = Bus(label="bus-uid2", type="bus-type")
+            assert self.es.nodes[1] == bus2
+            t1 = Transformer(label="pp_gas", inputs=[bus], outputs=[bus2])
+            assert t1 in self.es.nodes
+            self.es.timeindex = self.timeindex
+            assert len(self.es.timeindex) == 5
 
     def test_that_setting_a_node_registry_emits_a_warning(self):
         with pytest.warns(FutureWarning):

--- a/tests/node_registration_tests.py
+++ b/tests/node_registration_tests.py
@@ -18,8 +18,6 @@ import warnings
 
 import pandas as pd
 import pytest
-from nose.tools import eq_
-from nose.tools import ok_
 
 from oemof.network.energy_system import EnergySystem
 from oemof.network.network import Bus
@@ -44,13 +42,13 @@ class NodeRegistrationTests:
     def test_entity_registration(self):
         Node.registry = self.es
         bus = Bus(label='bus-uid', type='bus-type')
-        eq_(self.es.nodes[0], bus)
+        assert self.es.nodes[0] == bus
         bus2 = Bus(label='bus-uid2', type='bus-type')
-        eq_(self.es.nodes[1], bus2)
+        assert self.es.nodes[1] == bus2
         t1 = Transformer(label='pp_gas', inputs=[bus], outputs=[bus2])
-        ok_(t1 in self.es.nodes)
+        assert t1 in self.es.nodes
         self.es.timeindex = self.timeindex
-        ok_(len(self.es.timeindex) == 5)
+        assert len(self.es.timeindex) == 5
 
     def test_that_setting_a_node_registry_emits_a_warning(self):
         with pytest.warns(FutureWarning):

--- a/tests/node_registration_tests.py
+++ b/tests/node_registration_tests.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -
 
-""" Tests pertaining to :obj:`node {}` registration via :attr:`Node.registry <oemof.network.network.Node.registry>`.
+""" Tests pertaining to :obj:`node {}` registration via
+:attr:`Node.registry <oemof.network.network.Node.registry>`.
 
 This test suite (eventually) collects all tests revolving around automatically
 registering :obj:`nodes <oemof.network.network.Node>` in an
@@ -16,6 +17,7 @@ SPDX-License-Identifier: MIT
 """.format(
     "<oemof.network.network.Node>"
 )
+
 import warnings
 
 import pandas as pd

--- a/tests/node_registration_tests.py
+++ b/tests/node_registration_tests.py
@@ -13,7 +13,9 @@ by the contributors recorded in the version control history of the file,
 available from its original location oemof/tests/basic_tests.py
 
 SPDX-License-Identifier: MIT
-""".format("<oemof.network.network.Node>")
+""".format(
+    "<oemof.network.network.Node>"
+)
 import warnings
 
 import pandas as pd
@@ -31,7 +33,7 @@ class NodeRegistrationTests:
 
     @classmethod
     def setup_class(cls):
-        cls.timeindex = pd.date_range('1/1/2012', periods=5, freq='H')
+        cls.timeindex = pd.date_range("1/1/2012", periods=5, freq="H")
 
     def setup(self):
         self.es = EnergySystem()
@@ -41,11 +43,11 @@ class NodeRegistrationTests:
 
     def test_entity_registration(self):
         Node.registry = self.es
-        bus = Bus(label='bus-uid', type='bus-type')
+        bus = Bus(label="bus-uid", type="bus-type")
         assert self.es.nodes[0] == bus
-        bus2 = Bus(label='bus-uid2', type='bus-type')
+        bus2 = Bus(label="bus-uid2", type="bus-type")
         assert self.es.nodes[1] == bus2
-        t1 = Transformer(label='pp_gas', inputs=[bus], outputs=[bus2])
+        t1 = Transformer(label="pp_gas", inputs=[bus], outputs=[bus2])
         assert t1 in self.es.nodes
         self.es.timeindex = self.timeindex
         assert len(self.es.timeindex) == 5

--- a/tests/node_registration_tests.py
+++ b/tests/node_registration_tests.py
@@ -25,6 +25,12 @@ from oemof.network.network import Node
 class NodeRegistrationTests:
 
     # TODO: Move all other registration tests into this test suite.
+
+    def setup(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            Node.registry = None
+
     def test_that_setting_a_node_registry_emits_a_warning(self):
         with pytest.warns(FutureWarning):
             Node.registry = 1
@@ -32,3 +38,16 @@ class NodeRegistrationTests:
     def test_that_accessing_the_node_registry_emits_a_warning(self):
         with pytest.warns(FutureWarning):
             Node.registry
+
+    def test_that_node_creation_does_not_emit_a_warning(self):
+        with pytest.warns(None) as record:
+            n = Node()
+
+        recorded = [w for w in record.list if w.category is FutureWarning]
+        if recorded:
+            pytest.fail(
+                "Creating a node emitted the following `FutureWarning`s\n"
+                "although no warning was expected:\n{}".format(
+                    "\n---\n".join([str(w.message) for w in recorded])
+                )
+            )

--- a/tests/node_registration_tests.py
+++ b/tests/node_registration_tests.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -
 
-""" Tests pertaining to :obj:`node <oemof.network.network.Node>` registration via :attr:`Node.registry <oemof.network.network.Node.registry>`.
+""" Tests pertaining to :obj:`node {}` registration via :attr:`Node.registry <oemof.network.network.Node.registry>`.
 
 This test suite (eventually) collects all tests revolving around automatically
 registering :obj:`nodes <oemof.network.network.Node>` in an
@@ -13,10 +13,9 @@ by the contributors recorded in the version control history of the file,
 available from its original location oemof/tests/basic_tests.py
 
 SPDX-License-Identifier: MIT
-"""
+""".format("<oemof.network.network.Node>")
 import warnings
 
-import pandas as pd
 import pytest
 
 from oemof.network.energy_system import EnergySystem
@@ -42,7 +41,7 @@ class NodeRegistrationTests:
 
     def test_that_node_creation_does_not_emit_a_warning(self):
         with pytest.warns(None) as record:
-            n = Node()
+            Node()
 
         recorded = [w for w in record.list if w.category is FutureWarning]
         if recorded:
@@ -59,4 +58,4 @@ class NodeRegistrationTests:
             Node.registry = EnergySystem()
 
         with pytest.warns(FutureWarning):
-            n = Node()
+            Node()

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ commands =
     twine check dist/oemof*
     check-manifest {toxinidir}
     flake8 src tests setup.py
-    isort --verbose --check-only --diff --recursive src tests setup.py
+    isort --verbose --check-only --diff src tests setup.py
 
 
 [testenv:docs]


### PR DESCRIPTION
Automatic `Node` registration seems to have proven to be more troublesome than useful. As there has been the option to explicitly add `Node`s to `EnergySystem`s from the get go, we are deprecating automatic registration in favour of manually populating `EnergySystem`s. This PR will add appropriate warnings to the automatic registration subsystem, which notifies users of the deprecation so they can make the shift.